### PR TITLE
Update startup scripts for Python3

### DIFF
--- a/server/start_debug_server
+++ b/server/start_debug_server
@@ -3,4 +3,8 @@ source credentials.sh
 export PBL_CACHE=REDIS
 export SPOTIPY_REDIRECT_URI='http://localhost:8000/auth.html'
 
-python flask_server.py --debug
+REDIS_HOST="${REDIS_HOST:-localhost}"
+REDIS_PORT="${REDIS_PORT:-6379}"
+export REDIS_HOST REDIS_PORT
+
+python3 flask_server.py --debug

--- a/server/start_queue_processor
+++ b/server/start_queue_processor
@@ -2,7 +2,11 @@ source credentials.sh
 export PBL_CACHE=REDIS
 #python scheduler.py
 
-until python scheduler.py; do
+REDIS_HOST="${REDIS_HOST:-localhost}"
+REDIS_PORT="${REDIS_PORT:-6379}"
+export REDIS_HOST REDIS_PORT
+
+until python3 scheduler.py; do
     echo "queue processor'' crashed with exit code $?.  Respawning.." >&2
     sleep 1
 done

--- a/server/start_simple_server
+++ b/server/start_simple_server
@@ -1,4 +1,9 @@
 source credentials.sh
 export PBL_CACHE=REDIS
-./runner.full python flask_server.py
+
+REDIS_HOST="${REDIS_HOST:-localhost}"
+REDIS_PORT="${REDIS_PORT:-6379}"
+export REDIS_HOST REDIS_PORT
+
+./runner.full python3 flask_server.py
 #gunicorn flask_server:app -b localhost:8000

--- a/server/start_unicorn_server
+++ b/server/start_unicorn_server
@@ -2,7 +2,11 @@ source credentials.sh
 export PBL_CACHE=REDIS
 #python flask_server.py
 
-until gunicorn -w 4 flask_server:app -b localhost:5000; do
+REDIS_HOST="${REDIS_HOST:-localhost}"
+REDIS_PORT="${REDIS_PORT:-6379}"
+export REDIS_HOST REDIS_PORT
+
+until python3 -m gunicorn -w 4 flask_server:app -b localhost:5000; do
     echo "unicorn server crashed with exit code $?.  Respawning.." >&2
     sleep 1
 done


### PR DESCRIPTION
## Summary
- update start scripts to use python3
- add optional `REDIS_HOST` and `REDIS_PORT` environment variables

## Testing
- `bash -n server/start_debug_server server/start_simple_server server/start_unicorn_server server/start_queue_processor`
- `python3 -m py_compile server/flask_server.py server/scheduler.py server/spotify_auth.py server/program_manager.py server/shell.py server/redis_stats.py server/trim_db.py` *(fails: SyntaxError in flask_server.py)*

------
https://chatgpt.com/codex/tasks/task_e_68756abc1f78832c849bb17c5e082d67