### PR TITLE
Add Python setup docs and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
 # Smarter Playlists
 
-This is a web app for creating complex playlists
+This is a web app for creating complex playlists.
+
+## Setup
+
+1. Install Python 3 and `pip`.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Create a file named `credentials.sh` in the project root with your Spotify API credentials:
+   ```bash
+   export SPOTIPY_CLIENT_ID=<your client id>
+   export SPOTIPY_CLIENT_SECRET=<your client secret>
+   export SPOTIPY_REDIRECT_URI=http://localhost:8000/auth.html
+   ```
+
+## Running
+
+1. Start Redis:
+   ```bash
+   cd redis
+   ./start-redis
+   ```
+2. Start the queue processor:
+   ```bash
+   cd server
+   ./start_queue_processor
+   ```
+3. In another shell start the Flask app:
+   ```bash
+   cd server
+   ./start_simple_server
+   ```
+
+The application will now be available on `http://localhost:8000`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+Flask
+flask-cors
+redis
+requests
+simplejson
+spotipy
+pyen
+pbl
+cachelib
+cherrypy
+Werkzeug


### PR DESCRIPTION
## Summary
- add third-party packages to `requirements.txt`
- document Python 3 setup, dependency install, credentials, and server startup

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_68756ab69498832c911fcfa00160fdfb