### PR TITLE
Migrate codebase to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
 # Smarter Playlists
 
-This is a web app for creating complex playlists
+This project is a small proof of concept web application for building complex
+playlists.  The codebase was originally written for Python&nbsp;2 and has now been
+updated to work with modern versions of Python (3.8+).
+
+## Getting Started
+
+Install the required packages with pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+### Running the server
+
+The Flask server can be launched directly:
+
+```bash
+python3 server/flask_server.py
+```
+
+For development there are helper scripts inside `server/` such as
+`start_debug_server` and `start_simple_server` which now use `python3`.
+
+### Tests
+
+Unit tests can be executed with:
+
+```bash
+python3 server/tests.py
+```
+
+The tests rely on the external `pbl` package.  If it is not installed the test
+suite will fail to import the module.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Flask
+Flask-Cors
+redis
+requests
+spotipy
+cherrypy
+cachelib
+simplejson

--- a/server/cherrypy_server.py
+++ b/server/cherrypy_server.py
@@ -2,7 +2,7 @@ import os
 import sys
 import cherrypy
 from cherrypy import tools
-import ConfigParser
+import configparser
 import json
 import time
 import components
@@ -18,31 +18,31 @@ class SmarterPlaylistServer(object):
     @tools.json_out()
     def inventory(self):
         start = time.time()
-        print 'inventory'
+        print('inventory')
         results = {
             'status': 'ok',
             'inventory': components.exported_inventory,
             'types': components.inventory['types']
         }
-        print 'inventory', time.time() - start
+        print('inventory', time.time() - start)
         return results
 
     @cherrypy.expose
     @tools.json_out()
     @tools.json_in()
     def run(self):
-        print 'inventory'
+        print('inventory')
         start = time.time()
         # program = request.json
-        print cherrypy.request.headers
+        print(cherrypy.request.headers)
         cl = cherrypy.request.headers['Content-Length']
         #rawbody = cherrypy.request.body.read(int(cl))
         program = cherrypy.request.json
 
-        print 'got program', program
+        print('got program', program)
         status, obj = compiler.compile(program)
 
-        print 'compiled in', time.time() - start, 'secs'
+        print('compiled in', time.time() - start, 'secs')
 
         if 'max_tracks' in program:
             max_tracks = program['max_tracks']
@@ -54,19 +54,19 @@ class SmarterPlaylistServer(object):
         if status == 'ok':
             tracks = []
             tids = pbl.get_tracks(obj, max_tracks)
-            print
+            print()
             for i, tid in enumerate(tids):
-                print i, pbl.tlib.get_tn(tid)
+                print(i, pbl.tlib.get_tn(tid))
                 tracks.append(pbl.tlib.get_track(tid))
-            print
+            print()
             results['tracks'] = tracks
             results['name'] = obj.name
 
         results['time'] = time.time() - start
-        print 'compiled and executed in', time.time() - start, 'secs'
+        print('compiled and executed in', time.time() - start, 'secs')
         if app.trace:
-            print json.dumps(results, indent=4)
-        print 'run', time.time() - start
+            print(json.dumps(results, indent=4))
+        print('run', time.time() - start)
         return results
   
 

--- a/server/compiler.py
+++ b/server/compiler.py
@@ -65,7 +65,7 @@ def convert_val_to_type(val, type, program):
     elif type == 'bool':
         return OK, bool(val)
     elif type == 'port':
-        if isinstance(val, basestring):
+        if isinstance(val, str):
             status, compiled_program = compile_object(val, program)
             return status, compiled_program
         elif isinstance(val, list):
@@ -129,14 +129,14 @@ def compile_object(objname, program):
             if spec:
                 params = { }
 
-                for param, val in comp['sources'].items():
+                for param, val in list(comp['sources'].items()):
                     status, cval = get_param_val(param, val, spec, program)
                     if status == OK:
                         params[param] = cval
                     else:
                         return status + " in " + objname, None
 
-                for param, val in comp['params'].items():
+                for param, val in list(comp['params'].items()):
                     status, cval = get_param_val(param, val, spec, program)
                     if status == OK:
                         params[param] = cval
@@ -150,7 +150,7 @@ def compile_object(objname, program):
                     return OK, obj
                 except pbl.PBLException as e:
                     #traceback.print_exc()
-                    print 'e reason', e.reason
+                    print('e reason', e.reason)
                     raise pbl.PBLException(None, e.reason, objname)
                 except:
                     traceback.print_exc()
@@ -183,7 +183,7 @@ if __name__ == '__main__':
 
         status, obj = compile(source_obj)
         if status == OK:
-            print 'compiled! = running'
+            print('compiled! = running')
             pbl.show_source(obj, props= ['src', 'duration'])
         else:
-            print 'Whoops', status
+            print('Whoops', status)

--- a/server/components.py
+++ b/server/components.py
@@ -2090,11 +2090,11 @@ def is_valid_param_type(type):
     if type in inventory['types']:
         return True
 
-    print "invalid type", type
+    print("invalid type", type)
     return False
 
 def check_component(comp):
-    print "checking", comp["name"]
+    print("checking", comp["name"])
     '''
         {
             "name" : "Annotator",
@@ -2130,7 +2130,7 @@ def check_component(comp):
     assert "type" in comp
     assert "description" in comp
     if "params" in comp:
-        for name, param in comp["params"].items():
+        for name, param in list(comp["params"].items()):
             assert "description" in param
             assert "type" in param
             ptype = param['type']
@@ -2153,6 +2153,6 @@ if __name__ == '__main__':
     import json
     #get_genres()
     if False:
-        print json.dumps(exported_inventory, indent=4)
-        print ""
+        print(json.dumps(exported_inventory, indent=4))
+        print("")
 

--- a/server/flask_server.py
+++ b/server/flask_server.py
@@ -1,7 +1,7 @@
 import os
 from flask import Flask, request, jsonify, send_from_directory
-from flask.ext.cors import cross_origin
-from werkzeug.contrib.fixers import ProxyFix
+from flask_cors import cross_origin
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 import json
 import components
@@ -38,7 +38,7 @@ def inventory():
         'status': 'ok',
         'inventory': components.exported_inventory,
     }
-    print 'inventory', time.time() - start
+    print('inventory', time.time() - start)
     return jsonify(results)
 
 @app.route('/SmarterPlaylists/save', methods=['POST'])
@@ -169,7 +169,7 @@ def directory():
         token = auth.get_fresh_token(auth_code)
         if token:
             user = token['user_id']
-            print "directory", user
+            print("directory", user)
             total, dir = pm.directory(user, start, count)
 
             if len(dir) > 0:
@@ -355,7 +355,7 @@ def shared_info():
             if is_shared:
                 results['status'] = 'ok'
                 out = {}
-                for k, v in info.items():
+                for k, v in list(info.items()):
                     if k in keep_set:
                         out[k] = v
                 results['info'] = out
@@ -384,7 +384,7 @@ def publish():
 
     results = { }
     if not token:
-        print 'WARNING: bad auth token', auth_code
+        print('WARNING: bad auth token', auth_code)
         results['status'] = 'error'
         results['message'] = 'not authorized'
     else:
@@ -443,7 +443,7 @@ def run():
         results['tracks'] = tracks
         for i, tid in enumerate(results['tids']):
             if app.trace:
-                print i, pbl.tlib.get_tn(tid)
+                print(i, pbl.tlib.get_tn(tid))
             tracks.append(pbl.tlib.get_track(tid))
     return jsonify(results)
 
@@ -459,7 +459,7 @@ def schedule():
 
     token = auth.get_fresh_token(auth_code)
     if not token:
-        print 'WARNING: bad auth token', auth_code
+        print('WARNING: bad auth token', auth_code)
         results['status'] = 'error'
         results['message'] = 'not authorized'
     else:
@@ -470,7 +470,7 @@ def schedule():
         total = params['total']
         ok = True
 
-        print 'delta', delta, 'when', when, 'total', total
+        print('delta', delta, 'when', when, 'total', total)
 
         if delta != 0 and delta < min_delta:
             results['status'] = 'error'
@@ -508,12 +508,12 @@ def force_error():
     }
     bad = {}
     if bad['missing']:
-        print "forced error"
+        print("forced error")
     return jsonify(results)
 
 @app.errorhandler(Exception)
 def handle_invalid_usage(error):
-    print "error", error
+    print("error", error)
     traceback.print_stack()
     results = { 
         'status': 'internal_error',
@@ -533,11 +533,11 @@ if __name__ == '__main__':
         if arg == '--trace':
             app.trace = True
     if app.debug:
-        print 'debug  mode'
+        print('debug  mode')
         app.run(threaded=False, debug=True)
     elif app.wsgi:
         from gevent.wsgi import WSGIServer
-        print 'prod  mode'
+        print('prod  mode')
         http_server = WSGIServer(('', 5000), app)
         http_server.serve_forever()
     else:

--- a/server/kvstore.py
+++ b/server/kvstore.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
 
     def batch_write(count):
         start_time = time.time()
-        for i in xrange(count):
+        for i in range(count):
             pid = "%d12345678%d" %(i, i)
             payload = {
                 "contents": "contents for pid " + pid,
@@ -52,11 +52,11 @@ if __name__ == '__main__':
             put(pid, json.dumps(payload))
 
         delta = time.time() - start_time
-        print "wrote %d records in %d ms. %.4f ms per record" % (count, int(delta * 1000), (delta * 1000 / count))
+        print("wrote %d records in %d ms. %.4f ms per record" % (count, int(delta * 1000), (delta * 1000 / count)))
 
     def batch_read(count):
         pids = []
-        for i in xrange(count):
+        for i in range(count):
             pid = "%d12345678%d" %(i, i)
             pids.append(pid)
 
@@ -71,11 +71,11 @@ if __name__ == '__main__':
                 if contents:
                     found += 1
                     if verbose:
-                        print json.dumps(contents, indent=2)
+                        print(json.dumps(contents, indent=2))
 
 
         delta = time.time() - start_time
-        print "found %d of  %d records in %d ms. %.4f ms per record" % (found, count, int(delta * 1000), (delta * 1000 / count))
+        print("found %d of  %d records in %d ms. %.4f ms per record" % (found, count, int(delta * 1000), (delta * 1000 / count)))
 
         
     args = sys.argv[1:]
@@ -98,7 +98,7 @@ if __name__ == '__main__':
                 payload['extra'] = args.pop(0)
             write = True
         else:
-            print "unknown arg", arg
+            print("unknown arg", arg)
             sys.exit(1)
 
     if write:

--- a/server/mixer.py
+++ b/server/mixer.py
@@ -107,7 +107,7 @@ class Mixer(object):
         for idx, hartist in enumerate(reversed(self.artist_history)):
             if artist == hartist:
                 return idx + 1
-        return sys.maxint
+        return sys.maxsize
             
 
     def prep(self):

--- a/server/plugs.py
+++ b/server/plugs.py
@@ -2,7 +2,7 @@ import pbl
 import datetime
 import random
 import spotipy
-from werkzeug.contrib.cache import SimpleCache
+from cachelib import SimpleCache
 from pbl import spotify_plugs
 import simplejson as json
 import time
@@ -141,7 +141,7 @@ class TrackFilter(object):
                     return track
                 else:
                     if self.debug:
-                        print 'filtered out', pbl.tlib.get_tn(track)
+                        print('filtered out', pbl.tlib.get_tn(track))
             else:
                 break
         return None
@@ -179,7 +179,7 @@ class ArtistFilter(object):
                     return track
                 else:
                     if self.debug:
-                        print 'filtered out', pbl.tlib.get_tn(track)
+                        print('filtered out', pbl.tlib.get_tn(track))
             else:
                 break
         return None
@@ -429,9 +429,9 @@ class PlaylistSave(object):
             uri = find_playlist_by_name(sp, user, self.playlist_name)
 
         if uri:
-            print 'found',  uri
+            print('found',  uri)
         else:
-            print 'creating new', self.playlist_name, 'playlist'
+            print('creating new', self.playlist_name, 'playlist')
             response = sp.user_playlist_create(user, self.playlist_name)
             uri = response['uri']
 
@@ -439,14 +439,14 @@ class PlaylistSave(object):
         if pid:
             batch_size = 100
             uris = [ 'spotify:track:' + id for id in self.buffer]
-            for start in xrange(0, len(uris), batch_size):
+            for start in range(0, len(uris), batch_size):
                 turis = uris[start:start+batch_size]
                 if start == 0 and not self.append:
                     sp.user_playlist_replace_tracks(user, pid, turis)
                 else:
                     sp.user_playlist_add_tracks(user, pid, turis)
         else:
-            print "Can't get authenticated access to spotify"
+            print("Can't get authenticated access to spotify")
 
 
 class PlaylistSaveToNew(object):
@@ -514,11 +514,11 @@ class PlaylistSaveToNew(object):
         if pid:
             batch_size = 100
             uris = [ 'spotify:track:' + id for id in self.buffer]
-            for start in xrange(0, len(uris), batch_size):
+            for start in range(0, len(uris), batch_size):
                 turis = uris[start:start+batch_size]
                 sp.user_playlist_add_tracks(user, pid, turis)
         else:
-            print "Can't get authenticated access to spotify"
+            print("Can't get authenticated access to spotify")
 
 
 def get_pid_from_playlist_uri(uri):
@@ -557,7 +557,7 @@ def save_to_playlist(title, uri, tids):
 
     if not uri:
         response = sp.user_playlist_create(user, title)
-        print "create playlist", json.dumps(response, indent=4)
+        print("create playlist", json.dumps(response, indent=4))
         if 'uri' in response:
             uri = response['uri']
         else:
@@ -567,14 +567,14 @@ def save_to_playlist(title, uri, tids):
     if pid:
         batch_size = 100
         uris = [ 'spotify:track:' + id for id in tids]
-        for start in xrange(0, len(uris), batch_size):
+        for start in range(0, len(uris), batch_size):
             turis = uris[start:start+batch_size]
             if start == 0:
                 sp.user_playlist_replace_tracks(user, pid, turis)
             else:
                 sp.user_playlist_add_tracks(user, pid, turis)
     else:
-        print "Can't get authenticated access to spotify"
+        print("Can't get authenticated access to spotify")
     return uri
 
 class MySavedTracks(object):
@@ -1031,9 +1031,9 @@ class SeparateArtists(object):
         score = 0
         indexes = set()
 
-        for i in xrange(len(self.tracks) - 1):
+        for i in range(len(self.tracks) - 1):
             aname = self.tracks[i]['artist']
-            for j in xrange(i + 1, len(self.tracks)):
+            for j in range(i + 1, len(self.tracks)):
 
                 if j - i >= min_delta_allowed:
                     break
@@ -1065,7 +1065,7 @@ class SeparateArtists(object):
         cur_score, indexes = self.score_list()
         no_swap = 0
 
-        for i in xrange(max_tries):
+        for i in range(max_tries):
 
             if cur_score == 0 or len(indexes) == 0:
                 break
@@ -1417,39 +1417,39 @@ if __name__ == '__main__':
         pbl.show_source(src)
 
     if False:
-        print 'with dedup'
+        print('with dedup')
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         src = ArtistDeDup(src)
         pbl.show_source(src)
 
-        print 'no dedup'
+        print('no dedup')
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         pbl.show_source(src)
 
     if False:
-        print 'weighted source'
+        print('weighted source')
 
-        print 'factor', 1
+        print('factor', 1)
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         src = WeightedShuffler(src, 1)
         pbl.show_source(src)
 
-        print 'factor', 0
+        print('factor', 0)
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         src = WeightedShuffler(src, 0)
         pbl.show_source(src)
 
-        print 'factor', .5
+        print('factor', .5)
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         src = WeightedShuffler(src, .5)
         pbl.show_source(src)
 
-        print 'factor', .1
+        print('factor', .1)
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         src = WeightedShuffler(src, .1)
         pbl.show_source(src)
 
-        print 'factor', .01
+        print('factor', .01)
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         src = WeightedShuffler(src, .01)
         pbl.show_source(src)
@@ -1458,46 +1458,46 @@ if __name__ == '__main__':
         sixmonths = 60 * 60 * 24 * 30 * 6
         onemonth = 60 * 60 * 24 * 30 * 1
 
-        print "older than six months"
+        print("older than six months")
         src = RelativeDatedPlaylistSource("extender test", None, 'plamere',
             order_by_date_added=False, 
             tracks_added_since=None, tracks_added_before="6 months")
         pbl.show_source(src)
 
-        print "new than six months"
+        print("new than six months")
         src = RelativeDatedPlaylistSource("extender test", None, 'plamere',
             order_by_date_added=False, 
             tracks_added_since="six mnths", tracks_added_before="")
         pbl.show_source(src)
 
-        print "new than six months, older than one month"
+        print("new than six months, older than one month")
         src = RelativeDatedPlaylistSource("extender test", None, 'plamere',
             order_by_date_added=False, 
             tracks_added_since="six months", tracks_added_before="1 month")
         pbl.show_source(src)
 
     if False:
-        print 'std'
+        print('std')
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         pbl.show_source(src)
 
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         src = TextFilter(src, 'the', True, False)
-        print src.name 
+        print(src.name) 
         pbl.show_source(src)
 
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         src = TextFilter(src, 'the', False, False)
-        print src.name 
+        print(src.name) 
         pbl.show_source(src)
 
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         src = TextFilter(src, 'the', True, True)
-        print src.name 
+        print(src.name) 
         pbl.show_source(src)
 
     if False:
-        print 'std'
+        print('std')
         src = pbl.PlaylistSource('trap music', uri = 'spotify:user:spotify:playlist:4Ha7Qja6HY3AgvNBgWz87p')
         pbl.show_source(src)
 

--- a/server/program_manager.py
+++ b/server/program_manager.py
@@ -58,7 +58,7 @@ class ProgramManager:
             }
         '''
         if debug_exceptions:
-            print "WARNING: debugging exceptions"
+            print("WARNING: debugging exceptions")
 
 
     def add_program(self, user, program):
@@ -148,7 +148,7 @@ class ProgramManager:
                 info['shared'] = info['shared'] == 'True'
                 if "owner" not in info:
                     info["owner"] = user
-                    print "directory:patched owner", user
+                    print("directory:patched owner", user)
                 out.append(info)
         out.sort(key=lambda x:x['name'].lower())
         return total, out
@@ -223,7 +223,7 @@ class ProgramManager:
         pkey = mkkey('program-stats', pid)
         stats = self.r.hgetall(pkey)
         out = {}
-        for k, v in stats.items():
+        for k, v in list(stats.items()):
             out[k] = int(float(v))
         return out
 
@@ -257,12 +257,12 @@ class ProgramManager:
             pbl.engine.clearEnvData()
             token = self.auth.get_fresh_token(auth_code)
             if not token:
-                print 'WARNING: bad auth token', auth_code
+                print('WARNING: bad auth token', auth_code)
                 results['status'] = 'error'
                 results['message'] = 'not authorized'
             else:
                 delta = token['expires_at'] - time.time()
-                print 'cur token expires in', delta, 'secs'
+                print('cur token expires in', delta, 'secs')
                 user = token['user_id']
                 program = self.get_program(user, pid)
                 if not program:
@@ -270,10 +270,10 @@ class ProgramManager:
                 pbl.engine.setEnv('spotify_auth_token', token['access_token'])
                 pbl.engine.setEnv('spotify_user_id', token['user_id'])
 
-                print 'executing', user, pid
+                print('executing', user, pid)
                 # print '# executing', json.dumps(program, indent=4)
                 status, obj = compiler.compile(program)
-                print 'compiled in', time.time() - start, 'secs'
+                print('compiled in', time.time() - start, 'secs')
 
                 if 'max_tracks' in program:
                     max_tracks = program['max_tracks']
@@ -312,7 +312,7 @@ class ProgramManager:
             else:
                 cname = e.cname
             results['component'] = cname
-            print 'PBLException', json.dumps(results, indent=4)
+            print('PBLException', json.dumps(results, indent=4))
             traceback.print_exc()
             if debug_exceptions:
                 raise
@@ -320,14 +320,14 @@ class ProgramManager:
         except Exception as e:
             results['status'] = 'error'
             results['message'] = str(e)
-            print 'General Exception', json.dumps(results, indent=4)
+            print('General Exception', json.dumps(results, indent=4))
             traceback.print_exc()
             if debug_exceptions:
                 raise
 
         pbl.engine.clearEnvData()
         results['time'] = time.time() - start
-        print 'compiled and executed in', time.time() - start, 'secs'
+        print('compiled and executed in', time.time() - start, 'secs')
 
         self.add_stat(pid, 'last_run', time.time());
         if results['status'] == 'ok':
@@ -335,7 +335,7 @@ class ProgramManager:
         else:
             self.inc_stat(pid, 'errors');
 
-        print 'run', time.time() - start, results['status']
+        print('run', time.time() - start, results['status'])
         return results
 
     def share_program(self, user, pid):
@@ -389,14 +389,14 @@ if __name__ == '__main__':
 
     def show_dir(user):
         for pid in p.directory(user):
-            print pid,
+            print(pid, end=' ')
             program = p.get_program(user, pid)
             pprint.pprint(program)
-            print
+            print()
 
 
 
-    print 'dir', p.directory(user)
+    print('dir', p.directory(user))
 
     program = mk_program()
     p.add_program(user, program)

--- a/server/redis_stats.py
+++ b/server/redis_stats.py
@@ -4,5 +4,5 @@ import redis
 r = redis.StrictRedis(host='localhost', port=6379, db=0)
 
 
-print json.dumps(r.info(), indent=2)
-print "dbsize", r.dbsize()
+print(json.dumps(r.info(), indent=2))
+print("dbsize", r.dbsize())

--- a/server/reltime.py
+++ b/server/reltime.py
@@ -88,7 +88,7 @@ def parse_to_rel_time(str):
     if len(words) % 2 == 1:
         raise ValueError('bad time format: ' + str)
         
-    for i in xrange(0, len(words), 2):
+    for i in range(0, len(words), 2):
         snum = words[i]
         type = words[i + 1].lower()
 
@@ -137,25 +137,25 @@ if __name__ == '__main__':
     for stest, res in tests:
         time = parse_to_rel_time(stest)
         if time == res:
-            print "GOOD", stest, time
+            print("GOOD", stest, time)
         else:
-            print "BAD", stest, res, time
+            print("BAD", stest, res, time)
 
-    print
-    print 'testing bad patterns'
+    print()
+    print('testing bad patterns')
     for bp in bad_patterns:
         try:
             time = parse_to_rel_time(bp)
-            print 'BAD', 'unexpected parse of', bp
+            print('BAD', 'unexpected parse of', bp)
         except ValueError as e:
-            print 'GOOD', e
+            print('GOOD', e)
 
-    print "some time examples"
+    print("some time examples")
     for stest, res in tests:
-        print 'parse_to_rel_time("' + stest + '")', '->', res
+        print('parse_to_rel_time("' + stest + '")', '->', res)
 
-    print "some time examples"
+    print("some time examples")
     for stest, res in tests:
-        print "<li>" + stest + "</li>"
-    print
+        print("<li>" + stest + "</li>")
+    print()
 

--- a/server/scheduler.py
+++ b/server/scheduler.py
@@ -75,7 +75,7 @@ class Scheduler(object):
             'runs', 'total', 'when'])
 
         out = {}
-        for k, v in status.items():
+        for k, v in list(status.items()):
             if k in skip_fields:
                 continue
             if k in int_fields:
@@ -84,7 +84,7 @@ class Scheduler(object):
         return out
         
     def post_job(self, skey, when):
-        print 'posting', skey, 'to run in', when - time.time(), 'secs'
+        print('posting', skey, 'to run in', when - time.time(), 'secs')
         pipe = self.r.pipeline()
         pipe.hset(skey, 'status', 'queued')
         pipe.hset(skey, 'next_run', when)
@@ -141,16 +141,16 @@ class Scheduler(object):
     def wait_for_next(self):
         timeout = self.get_next_delta()
         if timeout > 0:
-            print 'waiting for', timeout, 'secs'
+            print('waiting for', timeout, 'secs')
             self.r.blpop(self.wait_queue, timeout)
         return self.get_next_item()
             
     def execute_job(self, skey):
         results = None
         info = self.r.hgetall(skey)
-        print 'execute_job', skey, info
+        print('execute_job', skey, info)
         if info:
-            print 'execute_job', info
+            print('execute_job', info)
             auth_code = info['auth_code']
             pid = info['pid']
             results = self.pm.execute_program(auth_code, pid, True)
@@ -179,9 +179,9 @@ class Scheduler(object):
         runs = int(info['runs'])
         delta = int(info['delta'])
 
-        print
-        print 'info', info
-        print
+        print()
+        print('info', info)
+        print()
 
         user = info['user']
         pid = info['pid']
@@ -223,23 +223,23 @@ class Scheduler(object):
         return int(time.time())
 
     def process_job_queue(self):
-        print 'starting job pusher'
+        print('starting job pusher')
         while True:
             skey = self.wait_for_next()
             if skey:
-                print '    pushing', skey
+                print('    pushing', skey)
                 self.r.rpush(self.proc_queue, skey)
 
     def process_jobs(self):
-        print 'starting job processor'
+        print('starting job processor')
         while True:
             _,skey = self.r.blpop(self.proc_queue)
             if skey:
-                print '   processing', skey
+                print('   processing', skey)
                 self.run_job(skey)
             else:
                 break
-        print 'shutting down job processor'
+        print('shutting down job processor')
 
     def start_processing_threads(self, threads=5):
         def worker():
@@ -247,33 +247,33 @@ class Scheduler(object):
 
         self.show_info()
 
-        for i in xrange(threads):
+        for i in range(threads):
             t = threading.Thread(target=worker)
             t.daemon = True
             t.start()
         sched.process_job_queue()
 
     def show_info(self):
-        count = self.r.zcount(self.job_queue, -sys.maxint, sys.maxint)
-        print 'job queue has', count, 'jobs'
+        count = self.r.zcount(self.job_queue, -sys.maxsize, sys.maxsize)
+        print('job queue has', count, 'jobs')
 
         
 def show_results(result):
     try:
-        print "%s %s %.2f" % (result['status'], fmt_date(result['runtime']), result['time'])
-        print result['oinfo']
-        print result['info']
+        print("%s %s %.2f" % (result['status'], fmt_date(result['runtime']), result['time']))
+        print(result['oinfo'])
+        print(result['info'])
         if result['status'] == 'ok':
-            print result['name']
-            print result['uri']
+            print(result['name'])
+            print(result['uri'])
         else:
-            print result['message']
-        print
+            print(result['message'])
+        print()
     except:
         raise
-        print "trouble showing formatted result"
-        print json.dumps(result, indent=2)
-        print
+        print("trouble showing formatted result")
+        print(json.dumps(result, indent=2))
+        print()
 
 def fmt_date(ts):
     the_date = date.fromtimestamp(ts)

--- a/server/shell.py
+++ b/server/shell.py
@@ -17,8 +17,8 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
     skips = set(['auth_code'])
 
     def do_test(self, line):
-        print self.my_redis
-        print 'hello world'
+        print(self.my_redis)
+        print('hello world')
 
     def do_EOF(self, line):
         return True
@@ -28,39 +28,39 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
         for key in self.my_redis.keys("directory:*"):
             users.append(key.split(':')[1])
         users.sort()
-        print ' '.join(users)
-        print "total users:", len(users)
+        print(' '.join(users))
+        print("total users:", len(users))
 
     def do_dir(self, line):
         users = line.strip().split()
         for user in users:
             total, directory = self.pm.directory(user, 0, 10000)
-            print 
-            print "total programs", total
+            print() 
+            print("total programs", total)
             for entry in directory:
-                print json.dumps(entry, indent=4)
+                print(json.dumps(entry, indent=4))
 
     def do_gstats(self, line):
         stats = self.my_redis.hgetall("global_stats")
-        skeys = [key for key in stats.keys()]
+        skeys = [key for key in list(stats.keys())]
         skeys.sort()
 
         for key in skeys:
-            print '  ', key, stats[key]
+            print('  ', key, stats[key])
 
     def do_redis_stats(self, line):
-        print json.dumps(self.my_redis.info(), indent=2)
-        print
-        for key, val  in self.my_redis.info().items():
+        print(json.dumps(self.my_redis.info(), indent=2))
+        print()
+        for key, val  in list(self.my_redis.info().items()):
             if "memory" in key:
-                print "%32.32s %s" % (key, str(val))
-        print
-        print "dbsize", self.my_redis.dbsize()
+                print("%32.32s %s" % (key, str(val)))
+        print()
+        print("dbsize", self.my_redis.dbsize())
 
     def do_system_status(self, line):
         admin = self.my_redis.hgetall("system-status")
-        for k, v in admin.items():
-            print k,v
+        for k, v in list(admin.items()):
+            print(k,v)
 
     def do_motd(self, line):
         if len(line) == 0:
@@ -80,7 +80,7 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
     def do_maint_mode(self, line):
         if len(line) == 0:
             mode = self.my_redis.hget("system-status", "maint_mode")
-            print "maint_mode", mode
+            print("maint_mode", mode)
         else:
             mode = 'true' if line == 'true' else 'false'
             self.my_redis.hset('system-status', 'maint_mode', mode)
@@ -88,7 +88,7 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
     def do_maint_key(self, line):
         if len(line) == 0:
             key = self.my_redis.hget("system-status", "maint_key")
-            print "maint_key", key
+            print("maint_key", key)
         else:
             self.my_redis.hset('system-status', 'maint_key', line)
 
@@ -104,12 +104,12 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
 
         for user in users:
             total, progs = self.pm.directory(user, 0, 1000)
-            print user, total, 'programs'
+            print(user, total, 'programs')
             for prog in progs:
-                print '   ', prog['pid'], prog['name'], '-', prog['description']
+                print('   ', prog['pid'], prog['name'], '-', prog['description'])
                 prog_total += 1
 
-        print prog_total, 'programs, for', len(users), 'users'
+        print(prog_total, 'programs, for', len(users), 'users')
 
     def do_sprogs(self, line):
         """ simple list of progs and descriptions """
@@ -131,7 +131,7 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
                     continue
                 if "untitled" in name:
                     continue
-                print "%s\t%s" %(name, description)
+                print("%s\t%s" %(name, description))
 
     def do_save_progs(self, line):
         """ this command was used exactly once to move all
@@ -148,15 +148,15 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
 
         for user in users:
             total, progs = self.pm.directory(user, 0, 1000)
-            print user, total, 'programs'
+            print(user, total, 'programs')
             for prog in progs:
-                print '   ', prog['pid'], prog['name'], '-', prog['description']
+                print('   ', prog['pid'], prog['name'], '-', prog['description'])
                 program = self.pm.get_program(user, prog['pid'])
                 if program:
                     self.pm.save_program_to_disk(user, program)
                 prog_total += 1
 
-        print prog_total, 'programs, for', len(users), 'users'
+        print(prog_total, 'programs, for', len(users), 'users')
 
     def do_purge_progs(self, line):
         """ this command was used exactly once to remove all
@@ -173,15 +173,15 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
 
         for user in users:
             total, progs = self.pm.directory(user, 0, 1000)
-            print user, total, 'programs'
+            print(user, total, 'programs')
             for prog in progs:
                 pid = prog['pid']
                 pkey = program_manager.mkprogkey(user, pid)
-                print '   ', prog['pid'], prog['name'], '-', prog['description'], pkey
+                print('   ', prog['pid'], prog['name'], '-', prog['description'], pkey)
                 self.my_redis.delete(pkey)
                 purge_total += 1
 
-        print "purged", purge_total, 'programs, for', len(users), 'users'
+        print("purged", purge_total, 'programs, for', len(users), 'users')
 
     def do_show_all_keys(self, line):
         cursor = 0
@@ -190,7 +190,7 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
             cursor, keys = self.my_redis.scan(cursor)
             for key in keys:
                 # print which, key
-                print key
+                print(key)
                 which += 1
             if cursor == 0:
                 break
@@ -212,7 +212,7 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
         bytes = 0
         for user in users:
             total, progs = self.pm.directory(user, 0, 1000)
-            print user, total, 'programs'
+            print(user, total, 'programs')
             for prog in progs:
                 pid = prog['pid']
                 pkey = program_manager.mkprogkey(user, pid)
@@ -220,15 +220,15 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
                 if data:
                     found +=1
                     bytes += len(data)
-                print '   ', found, bytes, prog['pid'], prog['name'], '-', prog['description'], pkey
-        print "found", found, "progs, with", bytes, "bytes"
+                print('   ', found, bytes, prog['pid'], prog['name'], '-', prog['description'], pkey)
+        print("found", found, "progs, with", bytes, "bytes")
 
     def do_pinfo(self, line):
         for pid in line.strip().split():
             info = self.pm.get_info(pid)
-            for key, val in info.items():
-                print '   ', key, val
-            print
+            for key, val in list(info.items()):
+                print('   ', key, val)
+            print()
 
     def do_top_components(self, line):
         if len(line) == 0:
@@ -242,46 +242,46 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
         counter = collections.Counter()
         for i, user in enumerate(users):
             total, progs = self.pm.directory(user, 0, 1000)
-            print i, user, total, 'programs'
+            print(i, user, total, 'programs')
             for prog in progs:
                 #print '   ', prog['pid'], prog['name'], '-', prog['description']
                 # print json.dumps(prog)
                 program = self.pm.get_program(prog['owner'], prog['pid'])
                 #print json.dumps(program, indent=4)
-                for name, comp in program['components'].items():
+                for name, comp in list(program['components'].items()):
                     type = comp['type']
                     counter[type] += 1
 
-        print
-        print "most common components"
-        print
+        print()
+        print("most common components")
+        print()
         for type, cnt in counter.most_common():
-            print cnt, type
+            print(cnt, type)
 
     def do_pstats(self, line):
         for pid in line.strip().split():
             stats = self.pm.get_stats(pid)
             if stats:
-                print 'runs:', stats['runs'], '  last run:',  \
-                    fmt_time(stats['last_run']), '  created:', fmt_time(stats['creation_date'])
-            print
+                print('runs:', stats['runs'], '  last run:',  \
+                    fmt_time(stats['last_run']), '  created:', fmt_time(stats['creation_date']))
+            print()
 
     def do_program(self, line):
         for pid in line.strip().split():
             owner = self.pm.get_info(pid, 'owner')
             program = self.pm.get_program(owner, pid)
-            print json.dumps(program, indent=4)
+            print(json.dumps(program, indent=4))
 
     def do_published(self, line):
         for pid in self.pm.get_published_programs():
             info = self.pm.get_info(pid)
             if info and 'owner' in info and 'name' in info:
-                print pid, info['owner'],  info['name']
-        print
+                print(pid, info['owner'],  info['name'])
+        print()
 
     def do_jobs(self, line):
         now = time.time()
-        print "Jobs in queue", self.my_redis.zcard(self.job_queue)
+        print("Jobs in queue", self.my_redis.zcard(self.job_queue))
         long_form = line == '-l'
         count = 1000
         if line:
@@ -290,17 +290,17 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
         items = self.my_redis.zrange(self.job_queue, 0, count,withscores=True,score_cast_func=int)
         for item in items:
             skey, next_time = item
-            print fmt_delta(next_time - now), skey
+            print(fmt_delta(next_time - now), skey)
             if long_form:
-                for key, val in self.my_redis.hgetall(skey).items():
+                for key, val in list(self.my_redis.hgetall(skey).items()):
                     if key not in self.skips:
-                        print "   ", key, val
-                print
-        print 'total jobs', len(items)
+                        print("   ", key, val)
+                print()
+        print('total jobs', len(items))
 
     def do_proc_queue(self, line):
         now = time.time()
-        print "Jobs in proc queue", self.my_redis.llen(self.proc_queue)
+        print("Jobs in proc queue", self.my_redis.llen(self.proc_queue))
         long_form = line == '-l'
         count = 1000
         if line:
@@ -308,15 +308,15 @@ class SmarterPlaylistsAdmin(cmd.Cmd):
 
         items = self.my_redis.lrange(self.proc_queue, 0, count)
         for item in items:
-            print(json.dumps(item, indent=4))
+            print((json.dumps(item, indent=4)))
 
     def do_purge_proc_queue(self, line):
         now = time.time()
-        print "Jobs in proc queue", self.my_redis.llen(self.proc_queue)
+        print("Jobs in proc queue", self.my_redis.llen(self.proc_queue))
 
         while True:
             val = self.my_redis.lpop(self.proc_queue)
-            print("popped", val)
+            print(("popped", val))
             if val is None:
                 break
     

--- a/server/spotify_auth.py
+++ b/server/spotify_auth.py
@@ -32,9 +32,9 @@ class SpotifyAuth(object):
         self.client_redirect_uri = os.environ.get('SPOTIPY_REDIRECT_URI')
         self.trace = False
 
-        print 'client id', self.client_id 
-        print 'client secret', self.client_secret 
-        print 'client redirect uri', self.client_redirect_uri 
+        print('client id', self.client_id) 
+        print('client secret', self.client_secret) 
+        print('client redirect uri', self.client_redirect_uri) 
 
         if self.client_id == None or self.client_secret == None or \
             self.client_redirect_uri == None:
@@ -81,9 +81,9 @@ class SpotifyAuth(object):
             user = token['user_id']
             self._put('token:' + code, token)
             if self.trace:
-                print 'added token to db', code, token
+                print('added token to db', code, token)
         else:
-            print "can't get user info, bailing"
+            print("can't get user info, bailing")
             return None
         return token
 
@@ -100,7 +100,7 @@ class SpotifyAuth(object):
         if r.status_code >= 200 and r.status_code < 300:
             token = r.json()
             if self.trace:
-                print 'got back token', token
+                print('got back token', token)
             return token
         else:
             return None
@@ -121,7 +121,7 @@ class SpotifyAuth(object):
         if r.status_code >= 200 and r.status_code < 300:
             new_token = r.json()
             if self.trace:
-                print 'got back token', token
+                print('got back token', token)
             if not 'refresh_token' in new_token:
                 new_token['refresh_token'] = token['refresh_token']
             return new_token
@@ -145,7 +145,7 @@ class SpotifyAuth(object):
         if len(r.text) > 0:
             results = r.json()
             if self.trace:  # pragma: no cover
-                print('RESP', results)
+                print(('RESP', results))
                 print()
             return results
         else:
@@ -177,7 +177,7 @@ if __name__ == '__main__':
     token = spauth.get_fresh_token(my_code)
     if token:
         remaining = token['expires_at'] - time.time()
-        print 'Got a token that expires in', remaining, 'seconds'
+        print('Got a token that expires in', remaining, 'seconds')
     else:
-        print 'no token for that code'
+        print('no token for that code')
 

--- a/server/start_debug_server
+++ b/server/start_debug_server
@@ -3,4 +3,4 @@ source credentials.sh
 export PBL_CACHE=REDIS
 export SPOTIPY_REDIRECT_URI='http://localhost:8000/auth.html'
 
-python flask_server.py --debug
+python3 flask_server.py --debug

--- a/server/start_queue_processor
+++ b/server/start_queue_processor
@@ -2,7 +2,7 @@ source credentials.sh
 export PBL_CACHE=REDIS
 #python scheduler.py
 
-until python scheduler.py; do
+until python3 scheduler.py; do
     echo "queue processor'' crashed with exit code $?.  Respawning.." >&2
     sleep 1
 done

--- a/server/start_simple_server
+++ b/server/start_simple_server
@@ -1,4 +1,4 @@
 source credentials.sh
 export PBL_CACHE=REDIS
-./runner.full python flask_server.py
+./runner.full python3 flask_server.py
 #gunicorn flask_server:app -b localhost:8000

--- a/server/tests.py
+++ b/server/tests.py
@@ -18,7 +18,7 @@ def runner(source, max_tracks = 100, props=[]):
 class TestPlugs(unittest.TestCase):
 
     def test_artist_dedup(self):
-        print 'with dedup'
+        print('with dedup')
         src = pbl.PlaylistSource("extender test", None, 'plamere')
         src = ArtistDeDup(src)
         de_dup_size = runner(src, 500)

--- a/server/trim_db.py
+++ b/server/trim_db.py
@@ -40,7 +40,7 @@ def trim_results(name):
         r.ltrim(name, 0, last_result_to_keep)
         trimmed_jobs += 1
 
-    print "%d %s %4d %8d %8d %8d %8d" % (i, fmt_date(results['runtime']), get_age(results['runtime']), total_jobs, removed_jobs, trimmed_jobs, keep_all_jobs)
+    print("%d %s %4d %8d %8d %8d %8d" % (i, fmt_date(results['runtime']), get_age(results['runtime']), total_jobs, removed_jobs, trimmed_jobs, keep_all_jobs))
 
 def count_results(name):
     global total_byte_count, expired_byte_count, unexpired_byte_count
@@ -54,7 +54,7 @@ def count_results(name):
             unexpired_byte_count += len(js)
         else:
             expired_byte_count += len(js)
-    print "%d %s %4d %8d %8d %8d" % (i, fmt_date(results['runtime']), get_age(results['runtime']), unexpired_byte_count, expired_byte_count, total_byte_count)
+    print("%d %s %4d %8d %8d %8d" % (i, fmt_date(results['runtime']), get_age(results['runtime']), unexpired_byte_count, expired_byte_count, total_byte_count))
 
 def show_results(name):
     results = r.lrange(name, 0, 100)
@@ -62,7 +62,7 @@ def show_results(name):
     for i, js in enumerate(results):
         results = json.loads(js)
         # print json.dumps(results, indent=4)
-        print "TTL", ttl
+        print("TTL", ttl)
         show_result(results)
 
 def expire_key(name):
@@ -70,15 +70,15 @@ def expire_key(name):
 
 
 def show_result(result):
-    print "%s %s %.2f" % (result['status'], fmt_date(result['runtime']), result['time'])
-    print result['oinfo']
-    print result['info']
+    print("%s %s %.2f" % (result['status'], fmt_date(result['runtime']), result['time']))
+    print(result['oinfo'])
+    print(result['info'])
     if result['status'] == 'ok':
-        print result['name']
-        print result['uri']
+        print(result['name'])
+        print(result['uri'])
     else:
-        print result['message']
-    print
+        print(result['message'])
+    print()
 
 def fmt_date(ts):
     date = datetime.date.fromtimestamp(ts)
@@ -148,4 +148,4 @@ if __name__ == '__main__':
         elif arg == '--expire':
             expire()
         else:
-            print "unknown arg", arg
+            print("unknown arg", arg)

--- a/test/run.py
+++ b/test/run.py
@@ -13,6 +13,6 @@ if __name__ == '__main__':
         results = response.json()
         if results['status'] == 'ok':
             for i, track in enumerate(results['tracks']):
-                print i + 1, track['title'], track['artist']
+                print(i + 1, track['title'], track['artist'])
         else:
-            print results['status']
+            print(results['status'])


### PR DESCRIPTION
## Summary
- modernize code with `2to3` and manual fixes
- update imports for Flask-Cors and Werkzeug
- replace deprecated `werkzeug.contrib.cache` with `cachelib`
- switch helper scripts to `python3`
- add requirements file and document usage

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 server/tests.py` *(fails: ModuleNotFoundError: No module named 'engine')*

------
https://chatgpt.com/codex/tasks/task_e_687571968fbc832ca1f1efa967fd8ab2