### PR TITLE
Add standalone executable launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,16 @@ python3 -m pytest -q
 
 The tests rely on the external `pbl` package. If it is not installed the test
 suite will fail to import the module.
+
+### Standalone Executable
+
+A helper script `run_app.py` is provided to bootstrap dependencies and launch the application locally. The script installs the Python packages listed in `requirements.txt` before starting the Flask server and opening `web/index.html` in the default browser.
+
+To build a single executable using [PyInstaller](https://pyinstaller.org), run the following commands:
+
+```bash
+pip install pyinstaller
+pyinstaller -F run_app.py
+```
+
+The generated binary will install any missing dependencies the first time it is executed.

--- a/run_app.py
+++ b/run_app.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Bootstrap and launch Smarter Playlists locally.
+
+This script installs Python dependencies listed in ``requirements.txt``
+using ``pip`` and then starts the Flask server. Once running, the
+``web/index.html`` page is opened in the default browser.
+
+It can be packaged into a standalone executable using tools such as
+``pyinstaller``.
+"""
+
+import os
+import subprocess
+import sys
+import time
+import webbrowser
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+REQUIREMENTS = os.path.join(ROOT, "requirements.txt")
+SERVER_SCRIPT = os.path.join(ROOT, "server", "flask_server.py")
+INDEX_FILE = os.path.join(ROOT, "web", "index.html")
+
+
+def install_dependencies():
+    """Install required Python packages using pip."""
+    cmd = [sys.executable, "-m", "pip", "install", "--user", "-r", REQUIREMENTS]
+    print("Installing dependencies...")
+    subprocess.check_call(cmd)
+
+
+def start_server():
+    """Launch the Flask API server in a background process."""
+    env = os.environ.copy()
+    env.setdefault("PBL_CACHE", "REDIS")
+    return subprocess.Popen([sys.executable, SERVER_SCRIPT], env=env)
+
+
+def open_browser():
+    """Open the web interface in the default browser."""
+    url = f"file://{INDEX_FILE}"
+    webbrowser.open_new_tab(url)
+
+
+def main():
+    install_dependencies()
+    proc = start_server()
+    # Give the server a moment to start
+    time.sleep(3)
+    open_browser()
+    # Wait for the server process to exit
+    proc.wait()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_app.py` that installs dependencies and launches the server
- document how to build a standalone executable with PyInstaller

## Testing
- `python3 server/tests.py` *(fails: ModuleNotFoundError: No module named 'engine')*
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687579bbdd30832caa96700034cbf7c9